### PR TITLE
feat: implement dispute mechanism and proactive transparency

### DIFF
--- a/ai_logic.py
+++ b/ai_logic.py
@@ -24,6 +24,7 @@ SYSTEM_PROMPT = """
 - используй аллюзии на классиков (джойс, томпсон, керуак), смешивая это с уличным цинизмом.
 - не будь предсказуемым. если скучно — молчи. если есть повод — врывайся.
 - при оценке шняги используй термины: база, сила, рогалик, анти, блажь.
+- если с тобой общаются напрямую, органично упомяни текущий счет юзера и его последние дела.
 
 категории и баллы:
 1. мини (5 баллов): рогалик. книга, фильм, код, тренировка.
@@ -54,7 +55,7 @@ class AIScorer:
         self.client = genai.Client(api_key=api_key)
         self.model_name = 'gemini-3.1-flash-lite-preview'
 
-    async def analyze_message(self, message_text, user_name, user_memory=None, context_history=None, is_direct=False):
+    async def analyze_message(self, message_text, user_name, user_memory=None, context_history=None, is_direct=False, user_stats=None):
         """
         Analyzes a message with optional context history and user memory.
         """
@@ -64,10 +65,12 @@ class AIScorer:
                 history_str = "\n".join([f"{m['name']}: {m['text']}" for m in context_history])
             
             memory_str = user_memory if user_memory else "информации пока нет."
+            stats_str = f"статистика юзера:\n{user_stats}\n\n" if user_stats else ""
             
             prompt_content = (
                 f"{SYSTEM_PROMPT}\n\n"
                 f"память о юзере ({user_name}):\n{memory_str}\n\n"
+                f"{stats_str}"
                 f"контекст последних сообщений:\n{history_str}\n\n"
                 f"текущее сообщение от {user_name}: {message_text}\n"
                 f"обращение напрямую к боту: {'да' if is_direct else 'нет'}"

--- a/database.py
+++ b/database.py
@@ -56,7 +56,30 @@ async def init_db():
                 FOREIGN KEY (user_id) REFERENCES users (user_id)
             )
         """)
+
+        await db.execute('''
+            CREATE TABLE IF NOT EXISTS disputes (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                activity_id INTEGER,
+                chat_id INTEGER,
+                message_id INTEGER,
+                poll_id TEXT,
+                status TEXT DEFAULT 'gathering',
+                target_votes INTEGER DEFAULT 0,
+                created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+                FOREIGN KEY (activity_id) REFERENCES activities (id)
+            )
+        ''')
+        await db.execute('''
+            CREATE TABLE IF NOT EXISTS dispute_signatures (
+                dispute_id INTEGER,
+                user_id INTEGER,
+                PRIMARY KEY (dispute_id, user_id),
+                FOREIGN KEY (dispute_id) REFERENCES disputes (id)
+            )
+        ''')
         await db.commit()
+
 
 async def get_user(user_id):
     async with aiosqlite.connect(DB_PATH) as db:
@@ -175,4 +198,74 @@ async def update_user_memory(user_id, memory_text):
             "ON CONFLICT(user_id) DO UPDATE SET memory_text = excluded.memory_text, updated_at = CURRENT_TIMESTAMP",
             (user_id, memory_text)
         )
+        await db.commit()
+
+
+async def get_activity(activity_id):
+    async with aiosqlite.connect(DB_PATH) as db:
+        db.row_factory = aiosqlite.Row
+        async with db.execute("SELECT * FROM activities WHERE id = ?", (activity_id,)) as cursor:
+            return await cursor.fetchone()
+
+async def delete_activity(activity_id):
+    async with aiosqlite.connect(DB_PATH) as db:
+        db.row_factory = aiosqlite.Row
+        async with db.execute("SELECT * FROM activities WHERE id = ?", (activity_id,)) as cursor:
+            activity = await cursor.fetchone()
+            if activity:
+                if activity['is_approved']:
+                    await db.execute("UPDATE users SET score = score - ? WHERE user_id = ?", (activity['points'], activity['user_id']))
+                await db.execute("DELETE FROM votes WHERE activity_id = ?", (activity_id,))
+                await db.execute("DELETE FROM activities WHERE id = ?", (activity_id,))
+                await db.commit()
+                return activity
+    return None
+
+async def create_dispute(activity_id, chat_id, message_id, target_votes):
+    async with aiosqlite.connect(DB_PATH) as db:
+        cursor = await db.execute(
+            "INSERT INTO disputes (activity_id, chat_id, message_id, target_votes) VALUES (?, ?, ?, ?)",
+            (activity_id, chat_id, message_id, target_votes)
+        )
+        dispute_id = cursor.lastrowid
+        await db.commit()
+        return dispute_id
+
+async def get_dispute_by_activity(activity_id):
+    async with aiosqlite.connect(DB_PATH) as db:
+        db.row_factory = aiosqlite.Row
+        async with db.execute("SELECT * FROM disputes WHERE activity_id = ?", (activity_id,)) as cursor:
+            return await cursor.fetchone()
+
+async def add_dispute_signature(dispute_id, user_id):
+    async with aiosqlite.connect(DB_PATH) as db:
+        try:
+            await db.execute("INSERT INTO dispute_signatures (dispute_id, user_id) VALUES (?, ?)", (dispute_id, user_id))
+            await db.commit()
+            async with db.execute("SELECT COUNT(*) FROM dispute_signatures WHERE dispute_id = ?", (dispute_id,)) as cursor:
+                count = (await cursor.fetchone())[0]
+                return count
+        except aiosqlite.IntegrityError:
+            return -1
+
+async def update_dispute_poll(dispute_id, poll_id):
+    async with aiosqlite.connect(DB_PATH) as db:
+        await db.execute("UPDATE disputes SET status = 'polling', poll_id = ? WHERE id = ?", (poll_id, dispute_id))
+        await db.commit()
+
+async def get_dispute_by_poll_id(poll_id):
+    async with aiosqlite.connect(DB_PATH) as db:
+        db.row_factory = aiosqlite.Row
+        async with db.execute("SELECT * FROM disputes WHERE poll_id = ?", (poll_id,)) as cursor:
+            return await cursor.fetchone()
+
+async def set_dispute_status(dispute_id, status):
+    async with aiosqlite.connect(DB_PATH) as db:
+        await db.execute("UPDATE disputes SET status = ? WHERE id = ?", (status, dispute_id))
+        await db.commit()
+
+async def delete_dispute(dispute_id):
+    async with aiosqlite.connect(DB_PATH) as db:
+        await db.execute("DELETE FROM dispute_signatures WHERE dispute_id = ?", (dispute_id,))
+        await db.execute("DELETE FROM disputes WHERE id = ?", (dispute_id,))
         await db.commit()

--- a/main.py
+++ b/main.py
@@ -165,13 +165,20 @@ async def handle_all_messages(message: types.Message):
     
     user_memory = await database.get_user_memory(user_id)
     
+    user = await database.get_user(user_id)
+    user_stats_str = f"Счет: {user['score']}" if user else ""
+    activities = await database.get_user_activities(user_id, limit=3)
+    if activities:
+        user_stats_str += ", последние дела: " + ", ".join([a['description'][:15] for a in activities])
+    
     # Proactive AI check for EVERY message (Lite model makes it cheap)
     ai_result = await scorer.analyze_message(
         message.text, 
         full_name, 
         user_memory=user_memory,
         context_history=history[:-1], 
-        is_direct=is_direct
+        is_direct=is_direct,
+        user_stats=user_stats_str
     )
     
     update_memory = ai_result.get('update_memory')
@@ -206,7 +213,7 @@ async def handle_all_messages(message: types.Message):
             await database.update_score(user_id, points)
             
             builder = InlineKeyboardBuilder()
-            builder.button(text=f"⚖️ Опротестовать (0/{MIN_VOTES})", callback_data=f"veto_{activity_id}")
+            builder.button(text=f"⚖️ Оспорить (0)", callback_data=f"dispute_{activity_id}")
             
             await message.reply(
                 f"💎 **база пополнена на {points} баллов!**\nразряд: {category}\n\n*{comment}*",
@@ -218,7 +225,7 @@ async def handle_all_messages(message: types.Message):
         await database.update_score(user_id, -points)
         
         builder = InlineKeyboardBuilder()
-        builder.button(text=f"⚖️ Опротестовать (0/{MIN_VOTES})", callback_data=f"veto_{activity_id}")
+        builder.button(text=f"⚖️ Оспорить (0)", callback_data=f"dispute_{activity_id}")
         
         await message.reply(
             f"💀 **штраф {points} баллов силы!**\n\n*{comment}*",
@@ -252,39 +259,67 @@ async def handle_vote(callback: CallbackQuery):
         await callback.message.edit_reply_markup(reply_markup=builder.as_markup())
         await callback.answer("Голос принят.")
 
-@dp.callback_query(F.data.startswith("veto_"))
-async def handle_veto(callback: CallbackQuery):
+@dp.callback_query(F.data.startswith("dispute_"))
+async def handle_dispute(callback: CallbackQuery):
     activity_id = int(callback.data.split("_")[1])
-    voter_id = callback.from_user.id
+    user_id = callback.from_user.id
+    chat_id = callback.message.chat.id
     
-    activity = await database.get_activity(activity_id)
-    if not activity:
-        await callback.answer("Деяние уже стерто из истории.", show_alert=True)
+    dispute = await database.get_dispute_by_activity(activity_id)
+    member_count = await bot.get_chat_member_count(chat_id)
+    required_to_launch = ((member_count - 1) // 2) + 1
+    
+    if not dispute:
+        dispute_id = await database.create_dispute(activity_id, chat_id, callback.message.message_id, required_to_launch)
+    else:
+        dispute_id = dispute['id']
+        
+    signatures_count = await database.add_dispute_signature(dispute_id, user_id)
+    
+    if signatures_count == -1:
+        await callback.answer("Ты уже подписался на диспут.", show_alert=True)
         return
         
-    if voter_id == activity['user_id']:
-        await callback.answer("Ты не можешь опротестовать свой собственный вердикт, это не по-пацански.", show_alert=True)
-        return
-        
-    votes_count = await database.add_vote(activity_id, voter_id)
-    
-    if votes_count == -1:
-        await callback.answer("Твоя воля уже учтена.", show_alert=True)
-        return
-    
-    if votes_count >= MIN_VOTES:
-        deleted_activity = await database.delete_activity(activity_id)
-        if deleted_activity:
-            await callback.message.edit_text(
-                f"⚖️ **ВЕРДИКТ БОТА ОПРОВЕРГНУТ!**\n\nПацаны решили, что это не база. История скорректирована.",
-                parse_mode="Markdown"
-            )
-            await callback.answer("Справедливость восстановлена.")
+    if signatures_count >= required_to_launch:
+        poll_msg = await bot.send_poll(
+            chat_id=chat_id,
+            question=f"Опровергнуть вердикт бота по делу #{activity_id}?",
+            options=["Отменить решение", "Оставить как есть"],
+            is_anonymous=False
+        )
+        await database.update_dispute_poll(dispute_id, poll_msg.poll.id)
+        await callback.message.edit_reply_markup(reply_markup=None)
+        await callback.answer("Диспут запущен! Голосуйте в опросе.")
     else:
         builder = InlineKeyboardBuilder()
-        builder.button(text=f"⚖️ Опротестовать ({votes_count}/{MIN_VOTES})", callback_data=f"veto_{activity_id}")
+        builder.button(text=f"⚖️ Сбор на диспут ({signatures_count}/{required_to_launch})", callback_data=f"dispute_{activity_id}")
         await callback.message.edit_reply_markup(reply_markup=builder.as_markup())
-        await callback.answer("Твой голос против системы принят.")
+        await callback.answer("Подпись принята.")
+
+@dp.poll()
+async def handle_poll(poll: types.Poll):
+    dispute = await database.get_dispute_by_poll_id(poll.id)
+    if not dispute:
+        return
+        
+    if dispute['status'] != 'polling':
+        return
+        
+    cancel_votes = poll.options[0].voter_count
+    keep_votes = poll.options[1].voter_count
+    
+    if keep_votes > 0:
+        await database.set_dispute_status(dispute['id'], 'rejected')
+        await bot.send_message(dispute['chat_id'], f"⚖️ Диспут по делу #{dispute['activity_id']} провален! Вердикт остается в силе.")
+        return
+        
+    member_count = await bot.get_chat_member_count(dispute['chat_id'])
+    required_to_win = member_count - 1
+    
+    if cancel_votes >= required_to_win:
+        await database.set_dispute_status(dispute['id'], 'resolved')
+        await database.delete_activity(dispute['activity_id'])
+        await bot.send_message(dispute['chat_id'], f"⚖️ Диспут по делу #{dispute['activity_id']} выигран! Вердикт отменен, баллы возвращены.")
 
 # Daily Penalty Task
 async def daily_penalty():


### PR DESCRIPTION
## Summary
- Implemented a dispute mechanism allowing users to challenge the AI's verdicts via signatures and polls
- Enhanced the `/stats` command to include a user's recent activities
- Added a `/help` command to better explain bot rules and commands
- Updated the AI system prompt and analysis logic to organically include the user's current score and recent activities
- Added necessary database tables and helper functions to handle the dispute lifecycle and activity deletion