### PR TITLE
Evaluate replied messages when mentioned

### DIFF
--- a/ai_logic.py
+++ b/ai_logic.py
@@ -71,7 +71,7 @@ class AIScorer:
         self.client = genai.Client(api_key=api_key)
         self.model_name = 'gemini-3.1-flash-lite-preview'
 
-    async def analyze_message(self, message_text, user_name, user_memory=None, context_history=None, is_direct=False, user_stats=None, reply_to_user=None, all_users=None):
+    async def analyze_message(self, message_text, user_name, user_memory=None, context_history=None, is_direct=False, user_stats=None, reply_to_user=None, all_users=None, replied_message_text=None):
         """
         Analyzes a message with optional context history and user memory.
         """
@@ -79,12 +79,18 @@ class AIScorer:
             history_str = ""
             if context_history:
                 for i, m in enumerate(context_history):
-                    reply_info = f" (в ответ {m['reply_to_name']})" if m.get('reply_to_name') else ""
-                    history_str += f"[{i}] {m['name']}{reply_info}: {m['text']}\n"
+                    reply_info_hist = f" (в ответ {m['reply_to_name']})" if m.get('reply_to_name') else ""
+                    history_str += f"[{i}] {m['name']}{reply_info_hist}: {m['text']}\n"
             
             memory_str = user_memory if user_memory else "информации пока нет."
             stats_str = f"статистика юзера:\n{user_stats}\n\n" if user_stats else ""
-            reply_info = f"это сообщение является ответом пользователю {reply_to_user}.\n" if reply_to_user else ""
+            
+            reply_info = ""
+            if reply_to_user:
+                reply_info = f"это сообщение является ответом (реплаем) пользователю {reply_to_user}.\n"
+                if replied_message_text:
+                    reply_info += f"ТЕКСТ ОРИГИНАЛЬНОГО СООБЩЕНИЯ (от {reply_to_user}): «{replied_message_text}»\n"
+                    reply_info += "ВНИМАНИЕ: Если тебя просят оценить это сообщение или выдать баллы, ты должен оценивать ИМЕННО ЭТОТ ОРИГИНАЛЬНЫЙ ТЕКСТ и (если нужно) выдавать баллы или штрафы ЕГО АВТОРУ, указав его в поле target_user!\n"
             
             users_list_str = ""
             if all_users:

--- a/main.py
+++ b/main.py
@@ -261,8 +261,8 @@ async def handle_all_messages(message: types.Message):
     all_users = await database.get_all_users()
     
     replied_message_text = None
-    if message.reply_to_message and message.reply_to_message.text:
-        replied_message_text = message.reply_to_message.text
+    if message.reply_to_message:
+        replied_message_text = message.reply_to_message.text or message.reply_to_message.caption
     
     # Proactive AI check for EVERY message (Lite model makes it cheap)
     ai_result = await scorer.analyze_message(

--- a/main.py
+++ b/main.py
@@ -260,6 +260,10 @@ async def handle_all_messages(message: types.Message):
     
     all_users = await database.get_all_users()
     
+    replied_message_text = None
+    if message.reply_to_message and message.reply_to_message.text:
+        replied_message_text = message.reply_to_message.text
+    
     # Proactive AI check for EVERY message (Lite model makes it cheap)
     ai_result = await scorer.analyze_message(
         message.text, 
@@ -269,7 +273,8 @@ async def handle_all_messages(message: types.Message):
         is_direct=is_direct,
         user_stats=user_stats_str,
         reply_to_user=reply_to_user,
-        all_users=all_users
+        all_users=all_users,
+        replied_message_text=replied_message_text
     )
     
     update_memory = ai_result.get('update_memory')


### PR DESCRIPTION
## Issue
When a user replies to someone else's message with a mention of the bot (e.g. "@supershnyagabot зацени это"), the AI received the context but often didn't clearly understand that it needed to evaluate the *original* message content and award points to the *original* author.

## Fix
- Added `replied_message_text` to the `analyze_message` signature.
- `main.py` now extracts the text from `message.reply_to_message` and passes it to the AI.
- Updated the AI prompt to explicitly wrap the original text and forcefully instruct the AI: "Если тебя просят оценить это сообщение или выдать баллы, ты должен оценивать ИМЕННО ЭТОТ ОРИГИНАЛЬНЫЙ ТЕКСТ и выдавать баллы ЕГО АВТОРУ, указав его в поле target_user!"