### PR TITLE
Fix reply targeting and prevent token spam

### DIFF
--- a/main.py
+++ b/main.py
@@ -247,6 +247,12 @@ async def handle_all_messages(message: types.Message):
 
     is_direct = await is_direct_to_bot(message)
     
+    if not is_direct:
+        # Save tokens and prevent spam: only call AI ~10-15% of the time for non-direct messages
+        wake_chance = min(CHANCE_REACT + (len(message.text or "") / 800), 0.15)
+        if random.random() > wake_chance:
+            return
+
     # [LOGGING] Inbound message details
     logger.info(f"[INBOUND] User ID: {user_id}, Name: {full_name}, Text: {message.text}, is_direct: {is_direct}")
     
@@ -321,16 +327,14 @@ async def handle_all_messages(message: types.Message):
             if not comment:
                 comment = "че тебе надо? формулируй мысль как пацан, а не рогалик."
         else:
-            # Chance to override ignore with a cynical random reaction
-            # Base chance + weight by message length (more to talk about)
-            # Maximum override chance of 25%
+            # We already passed the wake_chance gate to even call the AI.
+            # If the AI still wants to ignore, we have a smaller chance to force it to chat with its internal thought.
             override_chance = min(CHANCE_REACT + (len(message.text or "") / 500), 0.25)
             if random.random() < override_chance:
                 logger.info(f"[ACTION] Overriding 'ignore' with chance {override_chance:.2f} for user {full_name}")
                 if comment:
                     action = 'chat'
                 else:
-                    # If AI completely ignored the prompt to leave a thought, fallback to catchphrase
                     action = 'chat'
                     comment = random.choice(["даб даб", "даб даб я", "база", "че за блажь?"])
             else:


### PR DESCRIPTION
## Issue 1: Spam and Token Waste
Since the bot's Privacy Mode was disabled, it started sending an API request to Gemini for *every single message* in the chat. Not only does this burn through API tokens incredibly fast (costing money and hitting rate limits), but the AI also responded too often. The user requested: "накрутить рандомности и сто процентов отвечает только когда его отмечает или зовут по имени просто если он будет отвечать на все во первых засер во вторых токены потратятся быстро".

## Issue 2: Incorrect Reply Index
When the AI decided to reply to a normal message, it incorrectly guessed `reply_to_idx` (often pointing it at `0`, the oldest message in memory) instead of pointing it at the current message.

## Fix
- **Token Saver / Spam Reducer:** In `main.py`, if a message is *not* a direct mention or reply to the bot (`is_direct == False`), there is now a random check (~10-15% chance) *before* the Gemini API is even called. The bot will stay entirely silent 85% of the time, saving tokens.
- **Fixed Targeting:** In `ai_logic.py`, updated the prompt to explicitly instruct: *'Если ты отвечаешь на ТЕКУЩЕЕ СООБЩЕНИЕ, обязательно ставь "reply_to_idx": null. Используй индекс ТОЛЬКО если хочешь ответить на какое-то СТАРОЕ сообщение из истории.'* This ensures the bot replies to the right message.